### PR TITLE
Include boolean name convetion in bean generator

### DIFF
--- a/angulargwt/src/main/java/com/google/gwt/angular/rebind/BeanImplGenerator.java
+++ b/angulargwt/src/main/java/com/google/gwt/angular/rebind/BeanImplGenerator.java
@@ -184,8 +184,9 @@ class BeanImplGenerator {
 
 	private static boolean isGetter(JMethod method) {
 		String name = method.getName();
-		// traditional Type getFooField() JavaBean getter
-		if (name.startsWith("get") && Character.isUpperCase(name.charAt(3))) {
+		// traditional Type getFooField() or boolean Type isFoo() JavaBean getter
+		if (name.startsWith("get") && Character.isUpperCase(name.charAt(3))
+				|| name.startsWith("is") && Character.isUpperCase(name.charAt(2))) {
 			return method.getParameters().length == 0;
 			// non traditional Type foo() getter, needs to have paired setter to
 			// be detected correctly
@@ -199,6 +200,7 @@ class BeanImplGenerator {
 
 	private static boolean isBeanStyle(JMethod method) {
 		return method.getName().startsWith("get")
+				|| method.getName().startsWith("is")
 				|| method.getName().startsWith("set");
 	}
 	

--- a/angulargwt/src/main/java/com/google/gwt/angular/rebind/BeanImplGenerator.java
+++ b/angulargwt/src/main/java/com/google/gwt/angular/rebind/BeanImplGenerator.java
@@ -185,8 +185,8 @@ class BeanImplGenerator {
 	private static boolean isGetter(JMethod method) {
 		String name = method.getName();
 		// traditional Type getFooField() or boolean Type isFoo() JavaBean getter
-		if (name.startsWith("get") && Character.isUpperCase(name.charAt(3))
-				|| name.startsWith("is") && Character.isUpperCase(name.charAt(2))) {
+		if ((name.startsWith("get") && Character.isUpperCase(name.charAt(3)))
+				|| (name.startsWith("is") && Character.isUpperCase(name.charAt(2)))) {
 			return method.getParameters().length == 0;
 			// non traditional Type foo() getter, needs to have paired setter to
 			// be detected correctly


### PR DESCRIPTION
The bean generator was checking only for get\* methods. It happens that following JavaBean convention boolean methods can start with "is" prefix.
